### PR TITLE
 added control for numerical overflow

### DIFF
--- a/lib/estimation.js
+++ b/lib/estimation.js
@@ -96,6 +96,7 @@ function prepValuesOnFirstComparison(lookup, id) {
  * @param {Lookup} lookup
  * @param {Comparison[]} comparisons
  * @param {number} iteration
+ * @param {number} maxIncr
  * @function
  *
  */

--- a/lib/estimation.js
+++ b/lib/estimation.js
@@ -101,7 +101,8 @@ function prepValuesOnFirstComparison(lookup, id) {
  */
 function CML(lookup,
              comparisons,
-             iteration) {
+             iteration,
+             maxIncr) {
   //we need the values from the previous iteration
   const previousUnranked = cloneDeep(lookup.unrankedById);
 
@@ -127,7 +128,10 @@ function CML(lookup,
 
         //let's calculate the ability on the first 4 passes
         if (iteration > 0) {
-          current.ability = clamp(current.ability + ((current.selectedNum - expected.value) / expected.info), -10, 10);
+          if ( ((current.selectedNum - expected.value) / expected.info) > maxIncr )
+            var incr = maxIncr;
+          else var incr = ((current.selectedNum - expected.value) / expected.info);
+          current.ability = clamp(current.ability + incr, -10, 10);
         } else { // on the last pass we can calculate the standard error
           current.se = clamp(1 / Math.sqrt(expected.info), 200);
         }
@@ -176,10 +180,16 @@ module.exports = {
           obj.selectedNum = 0.003 + interm;
         });
 
+    //set maximum increment to avoid numerical underflow in CML function
+    //make increment smaler with every iteration
+    const incrFrac = 0.7;
+    var maxIncr = 3;
+
 
     //loop 4 times (+1) through the estimation
     for (let i = 4; i >= 0; i--) {
-      CML(lookup, comparisons, i);
+      maxIncr = maxIncr * incrFrac;
+      CML(lookup, comparisons, i, maxIncr);
     }
 
     return (isArray(items))

--- a/test/fixtures/mixedRankedResults.json
+++ b/test/fixtures/mixedRankedResults.json
@@ -91,8 +91,8 @@
         "_id": "Script12",
         "rankType": "to rank A",
         "ability": {
-            "value": -2.9975,
-            "se": 0.6772
+            "value": -2.2811,
+            "se": 0.977
         }
     },
     {
@@ -123,8 +123,8 @@
         "_id": "Script16",
         "rankType": "to rank",
         "ability": {
-            "value": -2.4978,
-            "se": 0.9329
+            "value": -2.5529,
+            "se": 0.9373
         }
     },
     {
@@ -163,8 +163,8 @@
         "_id": "Script21",
         "rankType": "to rank B",
         "ability": {
-            "value": -2.2283,
-            "se": 0.6313
+            "value": -1.1434,
+            "se": 0.913
         }
     },
     {
@@ -395,16 +395,16 @@
         "_id": "Script50",
         "rankType": "to rank B",
         "ability": {
-            "value": -1.0969,
-            "se": 0.4498
+            "value": -0.9876,
+            "se": 0.8482
         }
     },
     {
         "_id": "Script51",
         "rankType": "to rank A",
         "ability": {
-            "value": -1.0635,
-            "se": 0.4588
+            "value": -0.4748,
+            "se": 0.9189
         }
     },
     {
@@ -667,8 +667,8 @@
         "_id": "Script84",
         "rankType": "to rank B",
         "ability": {
-            "value": -0.1865,
-            "se": 0.42
+            "value": 1.55,
+            "se": 0.7115
         }
     },
     {
@@ -875,8 +875,8 @@
         "_id": "Script110",
         "rankType": "to rank A",
         "ability": {
-            "value": 0.4175,
-            "se": 0.4351
+            "value": -0.1587,
+            "se": 0.9551
         }
     },
     {
@@ -1147,8 +1147,8 @@
         "_id": "Script144",
         "rankType": "to rank B",
         "ability": {
-            "value": 1.4942,
-            "se": 0.4875
+            "value": 2.0328,
+            "se": 0.6942
         }
     },
     {
@@ -1315,16 +1315,16 @@
         "_id": "Script165",
         "rankType": "to rank B",
         "ability": {
-            "value": 2.2728,
-            "se": 0.5552
+            "value": 3.1042,
+            "se": 0.6655
         }
     },
     {
         "_id": "Script166",
         "rankType": "to rank A",
         "ability": {
-            "value": 2.2746,
-            "se": 0.5841
+            "value": 2.9362,
+            "se": 0.9412
         }
     },
     {
@@ -1435,8 +1435,8 @@
         "_id": "Script180",
         "rankType": "to rank A",
         "ability": {
-            "value": 3.6417,
-            "se": 0.7025
+            "value": 0.5557,
+            "se": 0.9636
         }
     },
     {
@@ -1459,9 +1459,8 @@
         "_id": "Script183",
         "rankType": "to rank",
         "ability": {
-            "value": 10,
-            "se": 9.2959
+            "value": 5.3193,
+            "se": 1.0252
         }
     }
 ]
-


### PR DESCRIPTION
When using the _positioning algorithm_ numerical overflow can occur. Namely, in most cases the cumulative Fisher information, calculated in
[line 18](https://github.com/d-pac/estimating-rasch-model/blob/ba0394b992dfeb5d21dbc3d08d61a3a7005b02f4/lib/estimation.js#L120) `memo.info += pm.fisher(prev.ability, opponent.ability);`
gets really big. This causes the _increment_, calculated by the part after the _+_ sign in
[line 130](https://github.com/d-pac/estimating-rasch-model/blob/ba0394b992dfeb5d21dbc3d08d61a3a7005b02f4/lib/estimation.js#L130) `current.ability = clamp(current.ability + ((current.selectedNum - expected.value) / expected.info), -10, 10);`
to get really small. This eventually causes numerical underflow leading to wrong and unstable estimates or even `NAN `or `Inf` values, i.e. the word explodes.
This causes the _positioning algorithm_ to do some funny things that we don't want it to do.

The adaptations in lines [192](https://github.com/SanVerhavert/estimating-rasch-model/blob/d4ec38e9ff6ea1b6fb54fb3c71f692994e25eed7/lib/estimation.js#L192), [132-135](https://github.com/SanVerhavert/estimating-rasch-model/blob/d4ec38e9ff6ea1b6fb54fb3c71f692994e25eed7/lib/estimation.js#L132-L135) and [106](https://github.com/SanVerhavert/estimating-rasch-model/blob/d4ec38e9ff6ea1b6fb54fb3c71f692994e25eed7/lib/estimation.js#L106) put a maximum on the increment, thus preventing the numerical underflow.